### PR TITLE
Bump version in libraries not using logging

### DIFF
--- a/pcss-criminal-application/pom.xml
+++ b/pcss-criminal-application/pom.xml
@@ -15,7 +15,7 @@
 	<description>PCSS Criminal Application</description>
 	<properties>
 		<java.version>11</java.version>
-		<log4j2.version>2.16.0</log4j2.version>
+		<log4j2.version>2.17.0</log4j2.version>
 	</properties>
 
 	<repositories>
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>com.splunk.logging</groupId>
 			<artifactId>splunk-library-javalogging</artifactId>
-			<version>1.11.1</version>
+			<version>1.11.2</version>
 			<scope>runtime</scope>
 		</dependency>
 		<!-- Logging framework -->

--- a/pcss-criminal-common/pom.xml
+++ b/pcss-criminal-common/pom.xml
@@ -15,7 +15,7 @@
 	<description>Common components</description>
 	<properties>
 		<java.version>11</java.version>
-		<log4j2.version>2.16.0</log4j2.version>
+		<log4j2.version>2.17.0</log4j2.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/pcss-criminal-common/pom.xml
+++ b/pcss-criminal-common/pom.xml
@@ -15,7 +15,7 @@
 	<description>Common components</description>
 	<properties>
 		<java.version>11</java.version>
-		<log4j2.version>2.15.0</log4j2.version>
+		<log4j2.version>2.16.0</log4j2.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/pcss-criminal-model/pom.xml
+++ b/pcss-criminal-model/pom.xml
@@ -15,7 +15,7 @@
 	<description>Model Project</description>
 	<properties>
 		<java.version>11</java.version>
-		<log4j2.version>2.15.0</log4j2.version>
+		<log4j2.version>2.16.0</log4j2.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/pcss-criminal-model/pom.xml
+++ b/pcss-criminal-model/pom.xml
@@ -15,7 +15,7 @@
 	<description>Model Project</description>
 	<properties>
 		<java.version>11</java.version>
-		<log4j2.version>2.16.0</log4j2.version>
+		<log4j2.version>2.17.0</log4j2.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/pcss-criminal-secure-model/pom.xml
+++ b/pcss-criminal-secure-model/pom.xml
@@ -15,7 +15,7 @@
 	<description>Model Project</description>
 	<properties>
 		<java.version>11</java.version>
-		<log4j2.version>2.15.0</log4j2.version>
+		<log4j2.version>2.16.0</log4j2.version>
 	</properties>
 	<dependencies>
 

--- a/pcss-criminal-secure-model/pom.xml
+++ b/pcss-criminal-secure-model/pom.xml
@@ -15,7 +15,7 @@
 	<description>Model Project</description>
 	<properties>
 		<java.version>11</java.version>
-		<log4j2.version>2.16.0</log4j2.version>
+		<log4j2.version>2.17.0</log4j2.version>
 	</properties>
 	<dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <description>PCSS criminal module</description>
     <properties>
         <java.version>11</java.version>
-        <log4j2.version>2.15.0</log4j2.version>
+        <log4j2.version>2.16.0</log4j2.version>
     </properties>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <description>PCSS criminal module</description>
     <properties>
         <java.version>11</java.version>
-        <log4j2.version>2.16.0</log4j2.version>
+        <log4j2.version>2.17.0</log4j2.version>
     </properties>
     <repositories>
         <repository>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Bump all log4j to 2.16

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring / Documentation
- [ ] Version change

