### PR TITLE
change the faultCode from CLIENT to SERVER to return status code 500 …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN mvn -ntp -B clean install \
 #############################################################################################
 ### Stage where Docker is running a java process to run a service built in previous stage ###
 #############################################################################################
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre-alpine
+
+RUN apk upgrade expat  # Fix for CVE-2022-43680
 
 ARG SERVICE_NAME=pcss-criminal-application
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jag-pcss-criminal
 
 [![Lifecycle:Stable](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/jag-pcss-criminal)
-[![Maintainability](https://api.codeclimate.com/v1/badges/602085fc42697705f899/maintainability)](https://codeclimate.com/github/bcgov/jag-pcss-criminal/maintainability) 
+[![Maintainability](https://api.codeclimate.com/v1/badges/602085fc42697705f899/maintainability)](https://codeclimate.com/github/bcgov/jag-pcss-criminal/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/602085fc42697705f899/test_coverage)](https://codeclimate.com/github/bcgov/jag-pcss-criminal/test_coverage)
 
 ### Recommended Tools

--- a/pcss-criminal-application/pom.xml
+++ b/pcss-criminal-application/pom.xml
@@ -83,6 +83,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
+            <version>5.7.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pcss-criminal-application/src/main/java/ca/bc/gov/open/pcsscriminalapplication/exception/ORDSException.java
+++ b/pcss-criminal-application/src/main/java/ca/bc/gov/open/pcsscriminalapplication/exception/ORDSException.java
@@ -4,7 +4,7 @@ import org.springframework.ws.soap.server.endpoint.annotation.FaultCode;
 import org.springframework.ws.soap.server.endpoint.annotation.SoapFault;
 
 @SoapFault(
-        faultCode = FaultCode.CLIENT,
+        faultCode = FaultCode.SERVER,
         faultStringOrReason =
                 "An error response was received from ORDS please check that your request is of valid form")
 public class ORDSException extends RuntimeException {

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
     <properties>
         <java.version>11</java.version>
         <log4j2.version>2.17.1</log4j2.version>
+        <snakeyaml.version>1.33</snakeyaml.version>
+        <jackson-bom.version>2.13.4.20221013</jackson-bom.version>
     </properties>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.12</version>
+        <version>2.7.3</version>
     </parent>
     <groupId>ca.bc.gov.open</groupId>
     <artifactId>pcss-criminal</artifactId>


### PR DESCRIPTION
…back to SOAP UI

# Description

This PR includes the following proposed change(s):

- {https://justice.gov.bc.ca/jira/browse/JADE-1774}

## Type of change

- currently,  PCSS returns status 400 (bad request) even if ORDS throws exceptions,  see the attachment.  The correct way is to show the status 500 to SOAP front.


- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
