### PR TITLE
Java17 Upgrade does not have the Jakarta conversion from xsd annotati…

### DIFF
--- a/pcss-criminal-application/src/test/java/ca/bc/gov/open/pcsscriminalapplication/controller/hearingcontroller/SetHearingRestrictionCriminalTest.java
+++ b/pcss-criminal-application/src/test/java/ca/bc/gov/open/pcsscriminalapplication/controller/hearingcontroller/SetHearingRestrictionCriminalTest.java
@@ -8,7 +8,6 @@ import ca.bc.gov.open.pcsscriminalapplication.properties.PcssProperties;
 import ca.bc.gov.open.pcsscriminalapplication.utils.LogBuilder;
 import ca.bc.gov.open.wsdl.pcss.one.SetHearingRestrictionCriminalResponse;
 import ca.bc.gov.open.wsdl.pcss.three.HearingRestrictionType;
-import ca.bc.gov.open.wsdl.pcss.three.OperationModeType;
 import ca.bc.gov.open.wsdl.pcss.two.SetHearingRestrictionCriminal;
 import ca.bc.gov.open.wsdl.pcss.two.SetHearingRestrictionCriminalRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -106,7 +105,7 @@ public class SetHearingRestrictionCriminalTest {
         setHearingRestrictionCriminalRequest1.setProfSeqNo("Test");
         setHearingRestrictionCriminalRequest1.setRequestAgencyIdentifierId("Test");
         setHearingRestrictionCriminalRequest1.setPartId("Test");
-        setHearingRestrictionCriminalRequest1.setOperationModeCd(OperationModeType.ADD);
+        setHearingRestrictionCriminalRequest1.setOperationModeCd("A");
 
         setHearingRestrictionCriminalRequest.setSetHearingRestrictionCriminalRequest(
                 setHearingRestrictionCriminalRequest1);

--- a/pcss-criminal-model/src/main/resources/xsdSchemas/pcss-1.xsd
+++ b/pcss-criminal-model/src/main/resources/xsdSchemas/pcss-1.xsd
@@ -268,7 +268,7 @@
     </xsd:element>
     <xsd:complexType name="Appearance">
         <xsd:sequence>
-            <xsd:element form="qualified" name="OperationModeCd" type="dx:OperationModeType"/>
+            <xsd:element form="qualified" name="OperationModeCd" type="xsd:string"/>
             <xsd:element form="qualified" name="TransactionDtm" type="dx:DateTimeType"/>
             <xsd:element form="qualified" name="ApprId" type="dx:SystemIdType"/>
             <xsd:element form="qualified" minOccurs="0" name="AppearanceDt" type="dx:DateType"/>
@@ -309,7 +309,7 @@
     </xsd:element>
     <xsd:complexType name="HearingRestriction">
         <xsd:sequence>
-            <xsd:element form="qualified" name="OperationModeCd" type="dx:OperationModeType"/>
+            <xsd:element form="qualified" name="OperationModeCd" type="xsd:string"/>
             <xsd:element form="qualified" name="TransactionDtm" type="dx:DateTimeType"/>
             <xsd:element form="qualified" name="HearingRestrictionId" type="dx:SystemIdType"/>
             <xsd:element form="qualified" minOccurs="0" name="AdjudicatorPartId" type="dx:SystemIdType"/>
@@ -378,7 +378,7 @@
     </xsd:element>
     <xsd:complexType name="Detail3">
         <xsd:sequence>
-            <xsd:element form="qualified" name="OperationModeCd" type="dx:OperationModeType"/>
+            <xsd:element form="qualified" name="OperationModeCd" type="xsd:string"/>
             <xsd:element form="qualified" name="ApprId" type="dx:SystemIdType"/>
             <xsd:element form="qualified" minOccurs="0" name="AssetUsageSeqNo" type="dx:SystemSeqNoType"/>
             <xsd:element form="qualified" minOccurs="0" name="RoleCd" type="dx:ParticipantRoleType"/>
@@ -433,7 +433,7 @@
                 <xsd:element form="qualified" name="RequestAgencyIdentifierId" type="dx:AgencyIdentifierType"/>
                 <xsd:element form="qualified" name="RequestPartId" type="dx:SystemIdType"/>
                 <xsd:element form="qualified" name="RequestDtm" type="dx:DateTimeType"/>
-                <xsd:element form="qualified" name="OperationModeCd" type="dx:OperationModeType"/>
+                <xsd:element form="qualified" name="OperationModeCd" type="xsd:string"/>
                 <xsd:element form="qualified" minOccurs="0" name="HearingRestrictionId" type="dx:SystemIdType"/>
                 <xsd:element form="qualified" minOccurs="0" name="AdjudicatorPartId" type="dx:SystemIdType"/>
                 <xsd:element form="qualified" minOccurs="0" name="HearingRestrictionCd" type="dx:HearingRestrictionType"/>
@@ -528,7 +528,7 @@
     </xsd:element>
     <xsd:complexType name="CrownAssignment2">
         <xsd:sequence>
-            <xsd:element form="qualified" name="OperationModeCd" type="dx:OperationModeType"/>
+            <xsd:element form="qualified" name="OperationModeCd" type="xsd:string"/>
             <xsd:element form="qualified" minOccurs="0" name="WorkAssignmentId" type="dx:SystemIdType"/>
             <xsd:element form="qualified" minOccurs="0" name="PaasAgencyId" type="dx:AgencyIdentifierType"/>
             <xsd:element form="qualified" minOccurs="0" name="PaasPartId" type="dx:SystemIdType"/>


### PR DESCRIPTION
…on tag to classes so change the field OperationModeCd to xsd:string to avoid type failure excep

tion while receiving JSON data from ORDS

# Description

This PR includes the following proposed change(s):

- {List all the changes, if possible add the jira ticket #}

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
